### PR TITLE
fix: task stream behavior

### DIFF
--- a/packages/tasks/supabase_tasks_api/lib/src/supabase_tasks_api.dart
+++ b/packages/tasks/supabase_tasks_api/lib/src/supabase_tasks_api.dart
@@ -15,6 +15,7 @@ class SupabaseTasksApi extends TasksApi {
   final SupabaseClient _supabaseClient;
 
   final _tasksController = TasksController();
+  DateTime? _date;
 
   Future<void> _updateData({required DateTime date}) async {
     final res = await _supabaseClient
@@ -35,7 +36,9 @@ class SupabaseTasksApi extends TasksApi {
 
   @override
   Stream<List<Task>> streamTasks({required DateTime date}) async* {
-    await _updateData(date: date);
+    if (_date != date) {
+      await _updateData(date: date);
+    }
     yield* _tasksController.stream;
   }
 

--- a/packages/tasks/tasks_repository/lib/src/tasks_repository.dart
+++ b/packages/tasks/tasks_repository/lib/src/tasks_repository.dart
@@ -11,18 +11,9 @@ class TasksRepository {
 
   final TasksApi _tasksApi;
 
-  DateTime? _dateCached;
-  late Stream<List<Task>> _streamCached;
-
   /// Provides a [Stream] of tasks from a [date]
-  Stream<List<Task>> streamTasks({required DateTime date}) {
-    if (date == _dateCached) return _streamCached;
-
-    _dateCached = date;
-
-    return _streamCached =
-        _tasksApi.streamTasks(date: date).asBroadcastStream();
-  }
+  Stream<List<Task>> streamTasks({required DateTime date}) =>
+      _tasksApi.streamTasks(date: date).asBroadcastStream();
 
   /// Saves a [task]
   ///


### PR DESCRIPTION
## Description

This PR solves an issue with the behavior of the tasks stream.

Previously the tasks stream was cached in its repository to avoid unnecessary API calls (same date); but since it was a broadcast stream when a new listener was added it didn't receive the data. e.g when the app theme changes a new subscription was requested for PlannerBloc but didn't receive the tasks until it changed the selected date.

Now that cache behavior is done directly in the APIs (as with activities), supabase API (where it is needed to reduce API calls) has a stream from a behavior subject avoiding the problem with a normal broadcast stream; and isar API doesn't need to cache the stream because is a local and fast database.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
